### PR TITLE
SDA-2476 Handle user swapping left/right mouse buttons

### DIFF
--- a/SelectRegion.h
+++ b/SelectRegion.h
@@ -104,7 +104,8 @@ static void CALLBACK timerProc( HWND hwnd, UINT message, UINT_PTR id, DWORD ms )
     }
 
     // Check if user have let go of mouse button
-    if( selectRegionData->dragging && ( GetAsyncKeyState( VK_LBUTTON ) & 0x8000 ) == 0 ) {
+    DWORD vk_button = GetSystemMetrics( SM_SWAPBUTTON ) ? VK_RBUTTON : VK_LBUTTON;
+    if( selectRegionData->dragging && ( GetAsyncKeyState( vk_button ) & 0x8000 ) == 0 ) {
         if( ( selectRegionData->bottomRight.x - selectRegionData->topLeft.x ) == 0 ||
             ( selectRegionData->bottomRight.y - selectRegionData->topLeft.y ) == 0 ) {
         selectRegionData->dragging = FALSE;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "screen-snippet",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "screen snippet util for windows, new version",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",

--- a/resources.rc
+++ b/resources.rc
@@ -5,7 +5,7 @@ IDR_ERASER            CURSOR                    "eraser.cur"
 
 #define VER_MAJOR 1
 #define VER_MINOR 0
-#define VER_REVISION 9
+#define VER_REVISION 10
 
 
 


### PR DESCRIPTION
Jira: https://perzoinc.atlassian.net/browse/SDA-2476

If the user have swapped left/right mouse button in control panel, the snippet tool was behaving incorrectly.

This fix detects if that setting has been changed, and swaps left/right button as necessary when calling GetAsyncKeyState. Note that the use of WM_LBUTTONDOWN does not need to be modified, as that is handled automatically by windows - but GetAsyncKeyState is not (see the Remarks section of https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-getasynckeystate)