### PR TITLE
SDA-2171 Fix offset error on win7

### DIFF
--- a/SelectRegion.h
+++ b/SelectRegion.h
@@ -337,6 +337,9 @@ static int selectRegion( RECT* region ) {
         SetWindowLongA( hwnd[ i ], GWL_STYLE, WS_VISIBLE );
         SetLayeredWindowAttributes( hwnd[ i ], transparent, 100, LWA_ALPHA | LWA_COLORKEY );
         UpdateWindow( hwnd[ i ] );
+
+        // Fix needed for running Win7 with classic theme. If we don't set position here, the whole window will be offset
+        SetWindowPos( hwnd[ i ], NULL, bounds.left, bounds.top, 0, 0, SWP_NOSIZE | SWP_NOZORDER | SWP_FRAMECHANGED );
     }
 
     // Call timer function directly - it will set up a timer based call to itself as the last thing it does

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "screen-snippet",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "description": "screen snippet util for windows, new version",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",

--- a/resources.rc
+++ b/resources.rc
@@ -5,7 +5,7 @@ IDR_ERASER            CURSOR                    "eraser.cur"
 
 #define VER_MAJOR 1
 #define VER_MINOR 0
-#define VER_REVISION 10
+#define VER_REVISION 11
 
 
 


### PR DESCRIPTION
When running windows 7 and using the classic theme, the screen snippet gets offset by a small amount. I don't know what is causing it, but found that by adding a call to set the position of the window after it's been initialized seems to fix it without any adverse effects on other themes or OS versions.