### PR TITLE
SDA-3167 Added version check before launching built-in snippet tool

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "screen-snippet",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "screen snippet util for windows, new version",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",

--- a/resources.rc
+++ b/resources.rc
@@ -4,7 +4,7 @@ IDR_PEN               CURSOR                    "pen.cur"
 IDR_ERASER            CURSOR                    "eraser.cur"
 
 #define VER_MAJOR 2
-#define VER_MINOR 0
+#define VER_MINOR 1
 #define VER_REVISION 0
 
 


### PR DESCRIPTION
Checking that windows build version is 10.0.15002 or later, before launching the windows snipping tool, as the /clip flag was first added in build 15002