### PR TITLE
SDA-3204 Emptying clipboard before calling SnippingTool

### DIFF
--- a/ScreenSnippet.cpp
+++ b/ScreenSnippet.cpp
@@ -263,6 +263,11 @@ int wmain( int argc, wchar_t* argv[] ) {
     info.lpFile = "SnippingTool";
     info.lpParameters = "/clip";
     info.nShow = SW_SHOWNORMAL ;    
+    if( !isOldWindows ) {
+        OpenClipboard( NULL );
+        EmptyClipboard();
+        CloseClipboard();
+    }
     if( !isOldWindows && ShellExecuteExA( &info ) ) {
         WaitForSingleObject( info.hProcess, INFINITE );
         if( IsClipboardFormatAvailable( CF_BITMAP ) ) {
@@ -335,7 +340,7 @@ extern "C" int __stdcall WinMain( struct HINSTANCE__*, struct HINSTANCE__*, char
     int argc = 0;
     LPWSTR* argv = CommandLineToArgvW( GetCommandLine(), &argc );
     int result = wmain( argc, argv ); 
-	LocalFree( argv );
-	return result;
+    LocalFree( argv );
+    return result;
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "screen-snippet",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "screen snippet util for windows, new version",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",

--- a/resources.rc
+++ b/resources.rc
@@ -4,7 +4,7 @@ IDR_PEN               CURSOR                    "pen.cur"
 IDR_ERASER            CURSOR                    "eraser.cur"
 
 #define VER_MAJOR 2
-#define VER_MINOR 2
+#define VER_MINOR 3
 #define VER_REVISION 0
 
 


### PR DESCRIPTION
If the clipboard already contains an image, and the user cancels the snipping tool by pressing ESC, then SDA will think the existing image is a new screen snippet. Therefore we empty the clipboard before running SnippingTool.