### PR TITLE
SDA-3203 Removed leftover delete which caused a crash on some Windows versions

### DIFF
--- a/ScreenSnippet.cpp
+++ b/ScreenSnippet.cpp
@@ -311,7 +311,6 @@ int wmain( int argc, wchar_t* argv[] ) {
             if( GetEncoderClsid( L"image/png", &pngClsid ) >= 0 ) {
                 wchar_t* filename = argv[ 1 ];
                 bmp.Save( filename ? filename : L"test_image.png", &pngClsid, NULL );
-                delete[] filename;
             }
         }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "screen-snippet",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "description": "screen snippet util for windows, new version",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",

--- a/resources.rc
+++ b/resources.rc
@@ -4,7 +4,7 @@ IDR_PEN               CURSOR                    "pen.cur"
 IDR_ERASER            CURSOR                    "eraser.cur"
 
 #define VER_MAJOR 2
-#define VER_MINOR 3
+#define VER_MINOR 4
 #define VER_REVISION 0
 
 


### PR DESCRIPTION
A stray delete[] had been left in when code was changed to support unicode command line params.